### PR TITLE
redirect to admin with trailing forward slash

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -52,6 +52,10 @@
   from = "/he/collections*"
   to = "/he/menu"
 
+[[redirects]]
+  from = "/admin$"
+  to = "/admin/"
+
 [[headers]]
   for = "/*"
   [headers.values]


### PR DESCRIPTION
To prevent Error: Failed to load config.yml